### PR TITLE
Sync shutdown gracefully

### DIFF
--- a/Tests/AppTests/AcronymTests.swift
+++ b/Tests/AppTests/AcronymTests.swift
@@ -47,6 +47,7 @@ final class AcronymTests : XCTestCase {
 
   override func tearDown() {
     conn.close()
+    try? app.syncShutdownGracefully()
   }
 
   func testAcronymsCanBeRetrievedFromAPI() throws {

--- a/Tests/AppTests/CategoryTests.swift
+++ b/Tests/AppTests/CategoryTests.swift
@@ -46,6 +46,7 @@ final class CategoryTests : XCTestCase {
 
   override func tearDown() {
     conn.close()
+    try? app.syncShutdownGracefully()
   }
 
   func testCategoriesCanBeRetrievedFromAPI() throws {

--- a/Tests/AppTests/UserTests.swift
+++ b/Tests/AppTests/UserTests.swift
@@ -47,6 +47,7 @@ final class UserTests : XCTestCase {
 
   override func tearDown() {
     conn.close()
+    try? app.syncShutdownGracefully()
   }
 
   func testUsersCanBeRetrievedFromAPI() throws {


### PR DESCRIPTION
Made sure the app is shutdown in the Unit tests to avoid the `too many clients` fatal error.